### PR TITLE
fix_visibility_call

### DIFF
--- a/weatherflow2mqtt/weatherflow_mqtt.py
+++ b/weatherflow2mqtt/weatherflow_mqtt.py
@@ -302,7 +302,6 @@ async def main():
                 data["precipitation_type"] = await cnv.rain_type(obs[13])
                 data["battery"] = round(obs[16], 2)
                 data["rain_rate"] = await cnv.rain_rate(obs[12])
-                data["visibility"] = await cnv.visibility(elevation)
                 data["uv_description"] = await cnv.uv_level(obs[10])
                 bft_value, bft_text = await cnv.beaufort(obs[2])
                 data["beaufort"] = bft_value
@@ -337,6 +336,7 @@ async def main():
                 data["delta_t"] = await cnv.delta_t(obs[7], obs[8], obs[6])
                 data["dewpoint_description"] = await cnv.dewpoint_level(data["dewpoint"])
                 data["temperature_description"] = await cnv.temperature_level(obs[7])
+                data["visibility"] = await cnv.visibility(elevation, data["air_temperature"], data["dewpoint"])
                 client.publish(state_topic, json.dumps(data))
                 await sql.writePressure(data["sealevel_pressure"])
                 await sql.updateHighLow(data)


### PR DESCRIPTION
Try to fix the following error
```
Traceback (most recent call last):
  File "/usr/local/bin/weatherflow2mqtt", line 33, in <module>
    sys.exit(load_entry_point('weatherflow2mqtt==0.10.0', 'console_scripts', 'weatherflow2mqtt')())
  File "/usr/local/lib/python3.9/site-packages/weatherflow2mqtt-0.10.0-py3.9.egg/weatherflow2mqtt/__main__.py", line 10, in main
  File "/usr/local/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.9/site-packages/weatherflow2mqtt-0.10.0-py3.9.egg/weatherflow2mqtt/weatherflow_mqtt.py", line 305, in main
TypeError: visibility() missing 2 required positional arguments: 'temp' and 'dewpoint_c'
```