### PR TITLE
Updated Visibility Calculation

### DIFF
--- a/weatherflow2mqtt/helpers.py
+++ b/weatherflow2mqtt/helpers.py
@@ -209,10 +209,34 @@ class ConversionFunctions:
             return None
 
         dewpoint_c = await self.dewpoint(temp, humidity, True)
+        # Set minimum elevation for cases of stations below sea level
+        if elvation > 2:
+            elv_min = float(elevation)
+        else:
+            elv_min = float(2)
+
+        # Max possible visibility to horizon (units km)
+        mv = float(3.56972 * math.sqrt(elv_min))
+
+        # Percent reduction based on quatity of water in air (no units)
+        # 76 percent of visibility variation can be accounted for by humidity accourding to US-NOAA.
+        pr_a = float((1.13 * abs(temp - dewpoint_c)-1.15)/10)
+        if pr_a > 1:
+            # Prevent visibility exceeding maximum distance
+            pr = float(1)
+        elif pr_a < 0.025:
+            # Prevent visibility below minimum distance
+            pr = float(0.025)
+        else:
+            pr = pr_a
+
+        # Visibility in km to horizon
+        vis = float(mv * pr)
 
         if self._unit_system == UNITS_IMPERIAL:
-            return round((1.22459 * math.sqrt(elevation * 3.2808))*((1.13*(temp - dewpoint_c)-1.15)/10), 1)
-        return round((3.56972 * math.sqrt(elevation))*((1.13*(temp - dewpoint_c)-1.15)/10), 1)
+            # Originally was in nautical miles; HA displays miles as imperial, therfore converted to miles
+            return round(vis/1.609344, 1)
+        return round(vis, 1)
 
     async def wetbulb(self, temp, humidity, pressure):
         """Returns the Wel Bulb Temperature.


### PR DESCRIPTION
I re-orginized the visibility calculation.

I found a condition if Air Temp and Dew Point are within a degree then the result is negative. I originally oversimplified the formula not to take into account the minimum visibility will always be 0.25 miles at sea level; that bit me when there is a small difference between the two.

I also did not previously take into account negative temperature (i.e. <0C)
Also, also did not take into account stations that could be below sea level. Set a minimum of 2 meters to prevent issues.

Added an absolute function call which should work without any other includes.

So, this will either be better or much worse. Only time will tell.