### PR TITLE
Home Assistant Supervisor Improvements

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -2,19 +2,24 @@
 
 This add-on allows you to get data from a WeatherFlow weather station using UDP. There is support for both the new Tempest station and the older AIR & SKY station.
 
+**Important**: this add-on uses the same timezone as your Home Assistant instance, so make sure it has been properly set.
+
 ## Installation
 
 To install the add-on, first follow the installation steps from the [README on GitHub](https://github.com/briis/hass-weatherflow2mqtt/blob/main/README.md).
 
 ## Configuration
 
-### Option: `TZ` (default: Same as Home Assistant)
-
-Set your local Timezone. It is important that you use the right timezone here, or else some of the calculations done by the container will not be correct.
-
 ### Option: `TEMPEST_DEVICE`: (default: True)
 
 If you have a Tempest Weather Station set this to True. If False, the program will assume you have the older AIR and SKY units. Default is *True*
+### Option: `FILTER_SENSORS`: (default: None)
+
+A comma-separated list of sensors to include instead of loading all sensors. Default is _None_, which disables filtering such that all sensors are loaded.
+
+### Option: `INVERT_FILTER`: (default: False)
+
+If set to True, `FILTER_SENSORS` will be treated as an exclusion list such that the specified sensors are ignored. Default is _False_.
 
 ### Option: `UNIT_SYSTEM`: (default: Same as Home Assistant)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-buster
 LABEL org.opencontainers.image.source="https://github.com/briis/hass-weatherflow2mqtt"
 
-RUN mkdir -p /usr/local/config
+RUN mkdir -p /data
 RUN mkdir -p /src/weatherflow2mqtt
 WORKDIR /src/weatherflow2mqtt
 ADD requirements.txt test_requirements.txt /src/weatherflow2mqtt/
@@ -15,23 +15,6 @@ RUN python setup.py install
 
 
 ENV TZ=Europe/Copenhagen
-ENV TEMPEST_DEVICE=True
-ENV UNIT_SYSTEM=metric
-ENV RAPID_WIND_INTERVAL=0
-ENV DEBUG=False
-ENV ELEVATION=0
-ENV WF_HOST=0.0.0.0
-ENV WF_PORT=50222
-ENV MQTT_HOST=127.0.0.1
-ENV MQTT_PORT=1883
-ENV MQTT_USERNAME=
-ENV MQTT_PASSWORD=
-ENV MQTT_DEBUG=False
-ENV ADD_FORECAST=False
-ENV STATION_ID=
-ENV STATION_TOKEN=
-ENV FORECAST_INTERVAL=30
-ENV LANGUAGE=en
 
 EXPOSE 50222/udp
 EXPOSE 1883

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # WeatherFlow-2-MQTT for Home Assistant
 
-![](https://img.shields.io/docker/v/briis/weatherflow2mqtt/latest?style=flat-square)  ![](https://img.shields.io/docker/pulls/briis/weatherflow2mqtt?style=flat-square)  [![](https://img.shields.io/badge/COMMUNITY-FORUM-success?style=flat-square)](https://community.weatherflow.com/t/weatherflow2mqtt-for-home-assistant/13718)
+![](https://img.shields.io/docker/v/briis/weatherflow2mqtt/latest?style=flat-square) ![](https://img.shields.io/docker/pulls/briis/weatherflow2mqtt?style=flat-square) [![](https://img.shields.io/badge/COMMUNITY-FORUM-success?style=flat-square)](https://community.weatherflow.com/t/weatherflow2mqtt-for-home-assistant/13718)
 
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fbriis%2Fhass-weatherflow2mqtt)
 
 This project monitors the UDP socket (50222) from a WeatherFlow Hub, and publishes the data to a MQTT Server. Data is formatted in a way that, it supports the [MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/) format for Home Assistant, so a sensor will created for each entity that WeatherFlow sends out, if you have MQTT Discovery enabled.
 
-Everything runs in a pre-build Docker Container, so installation is very simple, you only need Docker installed on a computer and a MQTT Server setup somewhere in your network. If you run the Supervised version of Home Assistant, you will have easy access to both. 
+Everything runs in a pre-built Docker Container, so installation is very simple. You only need Docker installed on a computer and a MQTT Server setup somewhere in your network. If you run either the Operating System or Supervised installation of Home Assistant, you will have easy access to both.
 
 There is support for both the AIR & SKY devices and the TEMPEST device.
 
@@ -24,9 +24,9 @@ There is support for both the AIR & SKY devices and the TEMPEST device.
 
 ## Installation
 
-### Home Assistant Supervised version
+### Home Assistant Supervised
 
-This is the easiest installation method. Just click the Blue Button which is labelled 'ADD INTEGRATION' and you will be taken to Home Assistant to add this repository to the Add-On store, from where you can install and configure it.
+This is the easiest installation method. Just click on the blue **ADD REPOSITORY** button at the top of this README and you will be taken to your Home Assistant instance to add this repository to the _Add-On Store_. From there, scroll down to find "WeatherFlow to MQTT" and then install, configure (optional) and start the add-on.
 
 ### Outside Home Assistant using Docker
 
@@ -43,12 +43,12 @@ If everything is setup correctly with MQTT and Home Assistant, you should now st
 
 The below command will pull the latest docker image and start WeatherFlow2MQTT for timezone Europe/Copenhagen and save data in the directory you are placed in when you launch the command. Ensure that you have replaced the Environment variables with your specific data. See description below.
 
-If you are using docker-compose you can use the [docker-compose.yml](docker-compose.yml) file and make the modifications for your environment.  
+If you are using docker-compose you can use the [docker-compose.yml](docker-compose.yml) file and make the modifications for your environment.
 
 ```bash
 docker run -d \
 --name=weatherflow2mqtt --restart=unless-stopped \
--v $(pwd):/usr/local/config \
+-v $(pwd):/data \
 -p 0.0.0.0:50222:50222/udp \
 -e TZ=Europe/Copenhagen \
 -e TEMPEST_DEVICE=True \
@@ -75,7 +75,7 @@ The container is build for both Intel and ARM platforms, so it should work on mo
 
 ### Docker Volume
 
-`-v YOUR_STORAGE_AREA:/usr/local/config` Please replace YOUR_STORAGE_AREA with a directory where Docker will have read and write access. It is also in this directory that you must place the *config.yaml* file if you don't want all the sensors (See [Installation](#installation)). Once the program runs, a SQLite Database with the name `weatherflow2mqtt.db` will be created in this directory. This database is used to hold some calculated values, store temporary data used for calculations and to ensure that you don't start from 0 if you have to restart Home Assistant or the container.
+`-v YOUR_STORAGE_AREA:/data` Please replace _YOUR_STORAGE_AREA_ with a directory where Docker will have read and write access. Once the program runs, a SQLite Database with the name `weatherflow2mqtt.db` will be created in this directory. This database is used to hold some calculated values, store temporary data used for calculations and to ensure that you don't start from 0 if you have to restart Home Assistant or the container. This is also where you can place the `config.yaml` file if you don't want all the sensors (see [Installation](#installation)).
 
 ### Docker Environment Variables
 
@@ -377,6 +377,7 @@ export MQTT_PASSWORD="..."
 ```
 
 Then you can run the daemon with
-```
-weatherflow2mqt
+
+```bash
+weatherflow2mqtt
 ```

--- a/config.json
+++ b/config.json
@@ -18,12 +18,8 @@
     "ports_description": {
         "50222/udp": "WeatherFlow socket"
     },
-    "map": [
-        "config:rw"
-    ],
     "environment": {
-        "HASS": "True",
-        "EXTERNAL_DIRECTORY": "/data"
+        "HA_SUPERVISOR": "True"
     },
     "services": [
         "mqtt:want"
@@ -32,8 +28,9 @@
         "TEMPEST_DEVICE": true
     },
     "schema": {
-        "TZ": "str?",
-        "TEMPEST_DEVICE": "bool?",
+        "TEMPEST_DEVICE": "bool",
+        "FILTER_SENSORS": "str?",
+        "INVERT_FILTER": "bool?",
         "UNIT_SYSTEM": "list(imperial|metric)?",
         "LANGUAGE": "list(en|da|de|fr)?",
         "RAPID_WIND_INTERVAL": "int?",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 services:
   weatherflow2mqtt:
     image: ghcr.io/briis/hass-weatherflow2mqtt:latest
@@ -7,7 +7,7 @@ services:
       - TZ=America/Los_Angeles
       - TEMPEST_DEVICE=True
       - UNIT_SYSTEM=imperial
-      - LANGUAGE=EN
+      - LANGUAGE=en
       - RAPID_WIND_INTERVAL=0
       - DEBUG=False
       - ELEVATION=0
@@ -23,6 +23,6 @@ services:
       - STATION_TOKEN=
       - FORECAST_INTERVAL=30
     volumes:
-      - /YOUR_STORAGE_AREA/PATH:/usr/local/config
+      - /YOUR_STORAGE_AREA/PATH:/data
     ports:
       - 0.0.0.0:50222:50222/udp

--- a/weatherflow2mqtt/const.py
+++ b/weatherflow2mqtt/const.py
@@ -18,7 +18,7 @@ ATTR_FORECAST_WIND_BEARING = "wind_bearing"
 ATTR_FORECAST_WIND_SPEED = "wind_speed"
 ATTR_FORECAST_HUMIDITY = "humidity"
 
-EXTERNAL_DIRECTORY = os.environ.get("EXTERNAL_DIRECTORY", "/usr/local/config")
+EXTERNAL_DIRECTORY = os.environ.get("EXTERNAL_DIRECTORY", "/data")
 INTERNAL_DIRECTORY = "/app"
 STORAGE_FILE = f"{EXTERNAL_DIRECTORY}/.storage.json"
 DATABASE = f"{EXTERNAL_DIRECTORY}/weatherflow2mqtt.db"
@@ -827,7 +827,6 @@ WEATHERFLOW_SENSORS = [
         False,
     ],
     # Sensor ID, Sensor Name, Unit Metric, Unit Imperial, Device Class, State Class, Icon, Update Event, Extra Attributes, Show Min Values, Show Last Reset
-
     [
         "tempest_status",
         "TEMPEST Status",
@@ -881,6 +880,8 @@ WEATHERFLOW_SENSORS = [
         False,
     ],
 ]
+
+OBSOLETE_SENSORS = ["uptime"]
 
 SENSOR_ID = 0
 SENSOR_NAME = 1

--- a/weatherflow2mqtt/forecast.py
+++ b/weatherflow2mqtt/forecast.py
@@ -208,11 +208,11 @@ class Forecast:
             _LOGGER.debug("Request to endpoint timed out: %s", endpoint)
         except ClientError as err:
             if "Unauthorized" in str(err):
-                _LOGGER.debug(
+                _LOGGER.error(
                     "Your API Key is invalid or does not support this operation"
                 )
             if "Not Found" in str(err):
-                _LOGGER.debug("The Station ID does not exis")
+                _LOGGER.error("The Station ID does not exist")
         except Exception as e:
             _LOGGER.debug("Error requesting data from %s Error: ", endpoint, e)
 

--- a/weatherflow2mqtt/helpers.py
+++ b/weatherflow2mqtt/helpers.py
@@ -1,12 +1,13 @@
 """Several Helper Functions."""
+from __future__ import annotations
 
 import datetime
 import json
 import logging
 import math
 from cmath import phase, rect
-from math import degrees, gamma, radians
-from typing import OrderedDict
+from math import degrees, radians
+from typing import Any
 
 import pytz
 import yaml
@@ -14,16 +15,23 @@ import yaml
 from weatherflow2mqtt.__version__ import VERSION
 from weatherflow2mqtt.const import (
     BATTERY_MODE_DESCRIPTION,
-    DEVICE_STATUS_MASKS,
     EXTERNAL_DIRECTORY,
+    DEVICE_STATUS_MASKS,
     SUPPORTED_LANGUAGES,
     UNITS_IMPERIAL,
 )
-from weatherflow2mqtt.sqlite import SQLFunctions
 
 UTC = pytz.utc
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def truebool(val: Any | None) -> bool:
+    """Return `True` if the value passed in matches a "True" value, otherwise `False`.
+
+    "True" values are: 'true', 't', 'yes', 'y', 'on' or '1'.
+    """
+    return val is not None and str(val).lower() in ("true", "t", "yes", "y", "on", "1")
 
 
 class ConversionFunctions:
@@ -217,15 +225,15 @@ class ConversionFunctions:
         # Format Relative Humidity
         RH = humidity / 100
         # Absolute Humidity Estimation is fairly acurate between (5C - 20C) (41F - 122F)
-        AH = (1320.65/TK)*RH*(10**((7.4475*(TK-273.14))/(TK-39.44)))
+        AH = (1320.65 / TK) * RH * (10 ** ((7.4475 * (TK - 273.14)) / (TK - 39.44)))
 
-        '''
+        """
         # lf/ft^3 is too small a value for that unit, will pass metric units just like Solar Radiation
         # Leaving conversion here for future reference
         if self._unit_system == UNITS_IMPERIAL:
             # (g/m^3 * 0.000062) converts to lb/ft^3
             return round(AH * 0.000062, 6)
-        '''
+        """
         return round(AH, 2)
 
     async def rain_rate(self, value):
@@ -685,7 +693,7 @@ class DataStorage:
 
     logging.basicConfig(level=logging.DEBUG)
 
-    async def read_config(self):
+    async def read_config(self) -> list[str] | None:
         """Reads the config file, to look for sensors."""
         try:
             filepath = f"{EXTERNAL_DIRECTORY}/config.yaml"
@@ -707,7 +715,7 @@ class DataStorage:
             if language not in SUPPORTED_LANGUAGES:
                 filename = "translations/en.json"
             else:
-                filename = f"translations/{language.lower()}.json"
+                filename = f"translations/{language}.json"
 
             with open(filename, "r") as json_file:
                 return json.load(json_file)

--- a/weatherflow2mqtt/sqlite.py
+++ b/weatherflow2mqtt/sqlite.py
@@ -48,7 +48,7 @@ class SQLFunctions:
         self._debug = debug
 
     async def create_connection(self, db_file):
-        """ create a database connection to a SQLite database """
+        """Create a database connection to a SQLite database."""
         try:
             self.connection = sqlite3.connect(db_file)
 
@@ -56,7 +56,7 @@ class SQLFunctions:
             _LOGGER.error("Could not create SQL Database. Error: %s", e)
 
     async def create_table(self, create_table_sql):
-        """create a table from the create_table_sql statement
+        """Create a table from the create_table_sql statement.
         :param conn: Connection object
         :param create_table_sql: a CREATE TABLE statement
         :return:
@@ -69,7 +69,7 @@ class SQLFunctions:
 
     async def create_storage_row(self, rowdata):
         """
-        Create a new storage row into the storage table
+        Create a new storage row into the storage table.
         :param conn:
         :param rowdata:
         :return: project id


### PR DESCRIPTION
Move configuration defaults to code and gracefully handle retrieval
Cleanup environment variables in Dockerfile since they are now handled in code
Simplify config loading between environment/supervisor options
Move mapped volume from /usr/local/config to /data to support supervisor
Remove TZ option from HA supervisor configuration since it should be loaded from HA
Add options for FILTER_SENSORS and INVERT_FILTER to avoid having to load a config.yaml file in HA
Add a list of obsolete sensors that can be used to handle cleanup of old sensors when they are deprecated and removed
