### PR TITLE
Various fixes/adjustments

### DIFF
--- a/weatherflow2mqtt/helpers.py
+++ b/weatherflow2mqtt/helpers.py
@@ -189,7 +189,8 @@ class ConversionFunctions:
             lp = gravity / (gas_constant * atm_rate)
             cp = gas_constant * atm_rate / gravity
             up = math.pow(
-                1 + math.pow(std_pressure / press, cp) * (atm_rate * elev / std_temp), lp
+                1 + math.pow(std_pressure / press, cp) * (atm_rate * elev / std_temp),
+                lp,
             )
             sea_pressure = press * up
 
@@ -255,12 +256,6 @@ class ConversionFunctions:
             return round(AH * 0.000062, 6)
         """
         return round(AH, 2)
-
-    def rain_rate(self, value):
-        """Return rain rate per hour."""
-        if not value:
-            return 0
-        return self.rain(value * 60)
 
     def rain_intensity(self, rain_rate) -> str:
         """Return a descriptive value of the rain rate.
@@ -676,9 +671,7 @@ class ConversionFunctions:
 
     def utc_last_midnight(self) -> str:
         """Return UTC Time for last midnight."""
-        midnight = dt.datetime.combine(
-            dt.datetime.today(), dt.time.min
-        )
+        midnight = dt.datetime.combine(dt.datetime.today(), dt.time.min)
         midnight_ts = dt.datetime.timestamp(midnight)
         midnight_dt = self.utc_from_timestamp(midnight_ts)
         return midnight_dt

--- a/weatherflow2mqtt/helpers.py
+++ b/weatherflow2mqtt/helpers.py
@@ -658,7 +658,7 @@ class ConversionFunctions:
 
     def utc_from_timestamp(self, timestamp: int) -> str:
         """Return a UTC time from a timestamp."""
-        if timestamp is None:
+        if not timestamp:
             return None
 
         # Convert to String as MQTT does not like data objects

--- a/weatherflow2mqtt/sensor_description.py
+++ b/weatherflow2mqtt/sensor_description.py
@@ -109,7 +109,17 @@ class StorageSensorDescription(BaseSensorDescription):
         return storage[self.storage_field]
 
 
+STATUS_SENSOR = SensorDescription(
+    id="status",
+    name="Status",
+    icon="clock-outline",
+    event=EVENT_STATUS_UPDATE,
+    attr="uptime",
+    device_class=DEVICE_CLASS_TIMESTAMP,
+)
+
 DEVICE_SENSORS: tuple[BaseSensorDescription, ...] = (
+    STATUS_SENSOR,
     SensorDescription(
         id="absolute_humidity",
         name="Absolute Humidity",
@@ -457,14 +467,6 @@ DEVICE_SENSORS: tuple[BaseSensorDescription, ...] = (
         decimals=(2, 3),
     ),
     SensorDescription(
-        id="status",
-        name="Status",
-        icon="clock-outline",
-        event=EVENT_STATUS_UPDATE,
-        attr="uptime",
-        device_class=DEVICE_CLASS_TIMESTAMP,
-    ),
-    SensorDescription(
         id="temperature_description",
         name="Temperature Level",
         icon="text-box-outline",
@@ -610,6 +612,8 @@ DEVICE_SENSORS: tuple[BaseSensorDescription, ...] = (
         decimals=(1, 2),
     ),
 )
+
+HUB_SENSORS: tuple[BaseSensorDescription, ...] = (STATUS_SENSOR,)
 
 FORECAST_SENSORS: tuple[BaseSensorDescription, ...] = (
     SensorDescription(

--- a/weatherflow2mqtt/sensor_description.py
+++ b/weatherflow2mqtt/sensor_description.py
@@ -358,23 +358,20 @@ DEVICE_SENSORS: tuple[BaseSensorDescription, ...] = (
         icon="text-box-outline",
         event=EVENT_OBSERVATION,
         attr="rain_accumulation_previous_minute",
-        custom_fn=lambda cnv, device: cnv.rain_intensity(
-            cnv.rain_rate(device.rain_accumulation_previous_minute.m)
-        ),
+        custom_fn=lambda cnv, device: cnv.rain_intensity(device.rain_rate.m),
     ),
     SensorDescription(
         id="rain_rate",
         name="Rain Rate",
         unit_m="mm/h",
+        unit_m_cnv="mm/hr",
         unit_i="in/h",
+        unit_i_cnv="in/hr",
         state_class=STATE_CLASS_MEASUREMENT,
         icon="weather-pouring",
         event=EVENT_OBSERVATION,
         extra_att=True,
-        attr="rain_accumulation_previous_minute",
-        custom_fn=lambda cnv, device: cnv.rain_rate(
-            device.rain_accumulation_previous_minute.m
-        ),
+        decimals=(2, 2),
     ),
     StorageSensorDescription(
         id="rain_start_time",

--- a/weatherflow2mqtt/weatherflow_mqtt.py
+++ b/weatherflow2mqtt/weatherflow_mqtt.py
@@ -689,8 +689,10 @@ class WeatherFlowMqtt:
             )
             condition_data, fcst_data = await self.forecast.update_forecast()
             if condition_data is not None:
-                self._add_to_queue(fcst_state_topic, json.dumps(condition_data))
-                self._add_to_queue(fcst_attr_topic, json.dumps(fcst_data))
+                self._add_to_queue(
+                    fcst_state_topic, json.dumps(condition_data), retain=True
+                )
+                self._add_to_queue(fcst_attr_topic, json.dumps(fcst_data), retain=True)
                 self.forecast_last_run = now
 
 

--- a/weatherflow2mqtt/weatherflow_mqtt.py
+++ b/weatherflow2mqtt/weatherflow_mqtt.py
@@ -306,8 +306,8 @@ class WeatherFlowMqtt:
         if (
             val := getattr(device, "rain_accumulation_previous_minute", None)
         ) is not None:
-            self.storage["rain_today"] += val.m
             if val.m > 0:
+                self.storage["rain_today"] += val.m
                 self.storage["rain_duration_today"] += 1
                 self.sql.writeStorage(self.storage)
 

--- a/weatherflow2mqtt/weatherflow_mqtt.py
+++ b/weatherflow2mqtt/weatherflow_mqtt.py
@@ -41,6 +41,7 @@ from .const import (
     ATTR_ATTRIBUTION,
     ATTRIBUTION,
     DATABASE,
+    DEVICE_CLASS_TIMESTAMP,
     DOMAIN,
     EVENT_HIGH_LOW,
     EXTERNAL_DIRECTORY,
@@ -57,6 +58,7 @@ from .helpers import ConversionFunctions, read_config, truebool
 from .sensor_description import (
     DEVICE_SENSORS,
     FORECAST_SENSORS,
+    HUB_SENSORS,
     OBSOLETE_SENSORS,
     BaseSensorDescription,
     SensorDescription,
@@ -515,8 +517,14 @@ class WeatherFlowMqtt:
         serial_number = device.serial_number
         domain_serial = DEVICE_SERIAL_FORMAT.format(DOMAIN, serial_number)
 
+        SENSORS = (
+            DEVICE_SENSORS
+            if isinstance(device, WeatherFlowSensorDevice)
+            else HUB_SENSORS
+        )
+
         # Create the config for the Sensors
-        for sensor in DEVICE_SENSORS:
+        for sensor in SENSORS:
             sensor_id = sensor.id
             sensor_event = sensor.event
 

--- a/weatherflow2mqtt/weatherflow_mqtt.py
+++ b/weatherflow2mqtt/weatherflow_mqtt.py
@@ -72,6 +72,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTRIBUTE_MISSING = object()
 MQTT_TOPIC_FORMAT = "homeassistant/sensor/{}/{}/{}"
 DEVICE_SERIAL_FORMAT = "{}_{}"
+UNKNOWN = "unknown"
 
 
 @dataclass
@@ -379,6 +380,10 @@ class WeatherFlowMqtt:
 
                     if (fn := sensor.cnv_fn) is not None:
                         attr = fn(self.cnv, attr)
+
+                # Handle timestamp None value
+                if sensor.device_class == DEVICE_CLASS_TIMESTAMP and attr is None:
+                    attr = UNKNOWN
 
                 # Set the attribute in the payload
                 data[sensor.id] = attr


### PR DESCRIPTION
- Uses rain_rate from the pyweatherflowudp package now that it is available
  - This should solve an issue with #100 where, when on imperial, rain rate was first converted to in/hr but then passed to rain intensity which is based on a mm/hr rate
- Sends the forecast data to MQTT with a retain=True value so that it can be restored on a Home Assistant restart instead of waiting for the next forecast update
- Reduces the loops for setting up the hub sensor by separating device and hub sensors
- Handles unknown timestamps for last lightning/rain so that it shows up as "Unknown" instead of "52 years ago" when there is no value