### PR TITLE
Bump pyweatherflowudp to 1.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ asyncio==3.4.3
 aiohttp==3.7.4.post0
 PyYAML==5.4.1
 pytz==2021.1
-pyweatherflowudp==1.1.1
+pyweatherflowudp==1.1.2


### PR DESCRIPTION
Corrects an error seen with #121 when a device is in low voltage mode