### PR TITLE
Call required loop method on MQTT client for handling messages

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -6,6 +6,5 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Add cloud base altitude and freezing level altitude sensors
-- Migrate sea level pressure sensor to use the pyweatherflowudp calculation
-- Bump pyweatherflowudp to 1.3.0
+- BUGFIX: Handle MQTT qos>0 messages appropriately by calling loop_start() on the MQTT client
+  - See https://github.com/eclipse/paho.mqtt.python#client

--- a/weatherflow2mqtt/weatherflow_mqtt.py
+++ b/weatherflow2mqtt/weatherflow_mqtt.py
@@ -168,6 +168,7 @@ class WeatherFlowMqtt:
             self.mqtt_client.connect(
                 self.mqtt_config.host, port=self.mqtt_config.port, keepalive=300
             )
+            self.mqtt_client.loop_start()
             _LOGGER.info(
                 "Connected to the MQTT server at %s:%s",
                 self.mqtt_config.host,
@@ -537,7 +538,6 @@ class WeatherFlowMqtt:
             _LOGGER.debug("MQTT Credentials not needed")
 
         self.mqtt_client = client = MqttClient()
-        client.max_inflight_messages_set(240)
 
         if not anonymous:
             client.username_pw_set(


### PR DESCRIPTION
See https://github.com/eclipse/paho.mqtt.python#network-loop for details

What is happening currently:
1. MQTT client is setup and connected with a maximum of 240 inflight messages
2. On initial load, each sensor that is set up adds a discovery and attribute message with qos=1, which increases the inflight message count by 2 (~100 with all current sensors for a single Tempest setup)
3. High/low update adds 1 to inflight messages each time (every ~10 minutes)
4. Weather forecast adds 1 to inflight messages each time (every ~30 minutes)
5. After ~18 hours, inflight messages exceeds the 240 threshold and new messages with qos=1 stop being processed right away and are queued instead, waiting for inflight messages to drop below the threshold which never happens

What this changes:
1. MQTT client is setup and connected with the default inflight messages of 20
   - The 240 seems to have been a workaround for messages not being published
2. `start_loop` is called on the MQTT client to start a thread that monitors the connection and processes incoming/outgoing messages
   - This loop is crucial because of qos>0 messages. It is what processes an incoming message from the MQTT broker to signal that messages were received properly and can be removed from the inflight messages, thus allowing future qos>0 messages to continue being processed
   - This also reduces the additional memory overhead from the increased inflight message count since they are now marked as published and can be removed from the list of pending messages


This should resolve #137 and #46.