### PR TITLE
Adding documentation regarding VLAN and subnet incompatibility.

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -82,6 +82,14 @@ Weatherflow always broadcasts on port 50222/udp, so don't change this. Default i
 
 Set this to True to enable more debug data in the Container Log.
 
+## Troubleshooting
+
+### VLANs and Subnets
+WeatherFlow2MQTT will not discover your base station if it is on a separate VLAN/subnet from your Home Assistant/Docker instance. Common indications that you are on a different VLAN are error messages such as:
+```weatherflow2mqtt.weatherflow_mqtt:Could not start listening to the UDP Socket. Error is: Could not open a local UDP endpoint```
+
+Although WeatherFlow2MQTT allows you to manually specify the Weatherflow host, there will still be issues getting the UDP broadcast to travel across the VLAN.
+
 ## Authors & contributors
 
 The original setup of this repository is by [Bjarne Riis](https://github.com/briis).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Please review Breaking Changes prior to updating your instance. Breaking changes
 
 A MQTT Server must be setup and configured on your local network, before installing this component. If you run a *Supervised* Home Assistant installation, we recommend using the MQTT Add-On available for this, else you must set it up yourself. See more [here](https://www.eclipse.org/paho/) for installing MQTT.
 
+**NOTE**: WeatherFlow2MQTT will not discover your base station if it is on a separate VLAN/subnet from your Home Assistant (or Docker) instance.
+
 ### Home Assistant Supervised
 
 This is the easiest installation method. Just click on the blue **ADD REPOSITORY** button at the top of this README and you will be taken to your Home Assistant instance to add this repository to the _Add-On Store_. From there, scroll down to find "WeatherFlow to MQTT" and then install, configure (optional) and start the add-on.


### PR DESCRIPTION
I spent an absurd amount of time trying to diagnose why WeatherFlow2MQTT [could not connect](https://github.com/briis/hass-weatherflow2mqtt/issues/4#issuecomment-855179643) to my base station either [through discovery](https://github.com/briis/hass-weatherflow2mqtt/issues/189#issuecomment-1346395062) or manually setting the WeatherFlow host directly.

In order to save future users time, I've added notes to both the README and the DOC regarding VLANs and subnets to assist with troubleshooting.