### PR TITLE
Optimize the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,20 @@ FROM python:3.10-slim-buster
 LABEL org.opencontainers.image.source="https://github.com/briis/hass-weatherflow2mqtt"
 
 RUN mkdir -p /data
-RUN mkdir -p /src/weatherflow2mqtt
 WORKDIR /src/weatherflow2mqtt
-ADD requirements.txt test_requirements.txt /src/weatherflow2mqtt/
-RUN apt-get clean
-RUN apt-get update && \
-    apt-get -y install build-essential
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
 
+ADD requirements.txt test_requirements.txt /src/weatherflow2mqtt/
+ADD weatherflow2mqtt /src/weatherflow2mqtt/weatherflow2mqtt/
 ADD setup.py /src/weatherflow2mqtt/
 ADD translations /src/weatherflow2mqtt/translations/
 
-ADD weatherflow2mqtt /src/weatherflow2mqtt/weatherflow2mqtt/
-RUN python setup.py install
+RUN apt-get update \
+    && apt-get -y install build-essential \
+    && pip install --upgrade --no-cache-dir pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && python setup.py install \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 
 ENV TZ=Europe/Copenhagen


### PR DESCRIPTION
Optimizing the Dockerfile results in a smaller image with fewer layers, which results in faster pulls and less space consumed when running weatherflow2mqtt.

The size of the image reduces from ~380MB to ~156MB.